### PR TITLE
fixed minor styling error on /about

### DIFF
--- a/src/components/accordion/Accordion.tsx
+++ b/src/components/accordion/Accordion.tsx
@@ -71,7 +71,7 @@ export default function Accordion({ data, colors }: AccordionProps) {
             />
           </div>
         </div>
-        <div className="min-h-200 mt-8 xs:w-auto xs:mt-8 sm:w-1/2">
+        <div className="min-h-200 xs:w-auto xs:mt-8 sm:mt-0 sm:w-1/2">
           <p className="text-red-0 sm:text-sm md:text-base">{text}</p>
         </div>
       </div>


### PR DESCRIPTION
Small bug I noticed while admiring my work...needed to remove the margin-top on the <div> wrapping the <p>{text}</p> when reverting to flex-row in small screens and up.